### PR TITLE
Changes to edit & code cleanup

### DIFF
--- a/app/src/main/java/com/example/mobil/CardFragment.kt
+++ b/app/src/main/java/com/example/mobil/CardFragment.kt
@@ -6,15 +6,10 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
-import android.widget.EditText
 import android.widget.TextView
 import androidx.navigation.fragment.navArgs
-import com.example.mobil.adapter.CardsAdapter
 import com.example.mobil.model.Card
 import com.google.firebase.firestore.*
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.ktx.Firebase
 
 // TODO: Use parameters?
 // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
@@ -23,7 +18,6 @@ private const val ARG_PARAM2 = "param2"
 
 class CardFragment : Fragment() {
     //testing ********************
-    private val argsDeck: DeckFragmentArgs by navArgs()
     private val argsCard: CardFragmentArgs by navArgs()
     //testing ********************
     private var cards = ArrayList<Card>()
@@ -49,14 +43,20 @@ class CardFragment : Fragment() {
         // Inflate the layout for this fragment
         val view = inflater.inflate(R.layout.fragment_card, container, false)
 
-        val db = Firebase.firestore
-        //database = FirebaseFirestore.getInstance()
+        return view
+    }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        eventChangeListener()
+        /*val db = Firebase.firestore
+        //database = FirebaseFirestore.getInstance()
 
         // filling (cards) up with all cards in the deck, in order to get a navigatable ArrayList
         var index = 0
         var cardIndex = 0
-        db.collection("Decks").document(argsCard.deckID.toString()).collection("cards").get()
+        db.collection("Decks").document(argsCard.deckId.toString()).collection("cards").get()
             .addOnSuccessListener { result ->
                 for (document in result) {
                     Log.d("TAG", "${document.id} => ${document.data}")
@@ -72,24 +72,20 @@ class CardFragment : Fragment() {
                                 false
                             )
                         )
-                        if (document.id == argsCard.cardID){
+                        if (document.id == argsCard.cardId){
                             index = cardIndex
                         }
                         cardIndex++
                     }
-
                 }
             }
             .addOnFailureListener { exception ->
                 Log.d("TAG", "Error getting documents: ", exception)
             }
 
-
-
         val cardText = view.findViewById<TextView>(R.id.cardTextView)
         cardText.setText(cards[index].question)
 
-        /*
         // Previous Card button
         val previousCardBtn = view.findViewById<Button>(R.id.previousCardButton)
         previousCardBtn.setOnClickListener{
@@ -125,32 +121,9 @@ class CardFragment : Fragment() {
                 cardText.setText(cards[index].question)
             }
         }
-        */
-
-
-
-
-
-
-
-
-
-
-        /*
-
-        //ToDo: Load deck instead of creating cards here
-        cards.add(Card("Card 0 Question", "Card 0 Answer", false))
-        cards.add(Card("Card 1 Question", "Card 1 Answer", false))
-        cards.add(Card("Card 2 Question", "Card 2 Answer", false))
-        cards.add(Card("Card 3 Question", "Card 3 Answer", false))
-        cards.add(Card("Card 4 Question", "Card 4 Answer", false))
 
         val cardText = view.findViewById<TextView>(R.id.cardTextView)
         cardText.setText(cards[index].question)
-
-
-
-
 
         // Previous Card button
         val previousCardBtn = view.findViewById<Button>(R.id.previousCardButton)
@@ -162,16 +135,7 @@ class CardFragment : Fragment() {
                 index -= 1
             }
             cardText.setText(cards[index].question)
-
-
-
-
         }
-
-
-
-
-
 
         // Next Card Button
         val nextCardBtn = view.findViewById<Button>(R.id.nextCardButton)
@@ -185,138 +149,59 @@ class CardFragment : Fragment() {
             cardText.setText(cards[index].question)
         }
 
-
-
-
-
         // Flip Card Button
-
-
-
         val flipCardBtn = view.findViewById<Button>(R.id.flipCardButton)
         flipCardBtn.setOnClickListener{
-
-
-
-
             if (cardText.text == cards[index].question) {
                 cardText.setText(cards[index].answer)
             }
-
             else {
-
-
                 cardText.setText(cards[index].question)
             }
         }
         */
-        return view
     }
 
-    /*
-
-
-    private fun eventChangeListener(adapter: CardsAdapter) {
-
-
-
+    private fun eventChangeListener() {
         database = FirebaseFirestore.getInstance()
         Log.e("Load Decks LOG", database.toString())
+        var index = 0
+        var cardIndex = 0
 
+        database.collection("Decks").document(argsCard.deckId.toString()).collection("cards")
+            .document(argsCard.cardId.toString()).get()
+            .addOnSuccessListener { result ->
+                for (document in result) {
+                    Log.d("TAG", "${document.id} => ${document.data}")
 
-        database.collection("Decks").document(argsDeck.docId.toString()).collection("cards")
-            .addSnapshotListener(object : EventListener<QuerySnapshot> {
-                override fun onEvent(
-                    value: QuerySnapshot?,
-                    error: FirebaseFirestoreException?
-                ) {
-
-
-                    if (error != null) {
-                        Log.e("Firestore Error", error.message.toString())
-                        return
-
-                    }
-
-
-
-                    for (dc: DocumentChange in value?.documentChanges!!) {
-                        if (dc.type == DocumentChange.Type.ADDED) {
-                            cards.add(dc.document.toObject(Card::class.java))
-                            Log.e("Load Decks LOG", cards.toString())
+                    // ToDo: This doesn't prevent the user to click on a ignored card, which will mess up the indexing
+                    // Todo: Possible fix is to present the first card directly without the using the arraylist
+                    // Todo: Then when you navigate, you cannot navigate back to this card
+                    if (document.data.getValue("isIgnored") == false) {
+                        cards.add(
+                            Card(
+                                document.data.getValue("question") as String?,
+                                document.data.getValue("answer") as String?,
+                                false
+                            )
+                        )
+                        if (document.id == argsCard.cardId) {
+                            index = cardIndex
                         }
-
-
+                        cardIndex++
                     }
-
-
-
-                    adapter.notifyDataSetChanged()
                 }
+            }
+            .addOnFailureListener { exception ->
+                Log.d("TAG", "Error getting documents: ", exception)
+            }
 
-            })
+        view?.findViewById<TextView>(R.id.cardTextView)?.text = cards[index].question
+
 
     }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    */
     companion object {
         /**
          * Use this factory method to create a new instance of

--- a/app/src/main/java/com/example/mobil/CardFragment.kt
+++ b/app/src/main/java/com/example/mobil/CardFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.TextView
 import androidx.navigation.fragment.navArgs
 import com.example.mobil.model.Card
@@ -50,41 +51,9 @@ class CardFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         eventChangeListener()
-        /*val db = Firebase.firestore
-        //database = FirebaseFirestore.getInstance()
 
-        // filling (cards) up with all cards in the deck, in order to get a navigatable ArrayList
         var index = 0
         var cardIndex = 0
-        db.collection("Decks").document(argsCard.deckId.toString()).collection("cards").get()
-            .addOnSuccessListener { result ->
-                for (document in result) {
-                    Log.d("TAG", "${document.id} => ${document.data}")
-
-                    // ToDo: This doesn't prevent the user to click on a ignored card, which will mess up the indexing
-                    // Todo: Possible fix is to present the first card directly without the using the arraylist
-                    // Todo: Then when you navigate, you cannot navigate back to this card
-                    if (document.data.getValue("isIgnored") == false) {
-                        cards.add(
-                            Card(
-                                document.data.getValue("question") as String?,
-                                document.data.getValue("answer") as String?,
-                                false
-                            )
-                        )
-                        if (document.id == argsCard.cardId){
-                            index = cardIndex
-                        }
-                        cardIndex++
-                    }
-                }
-            }
-            .addOnFailureListener { exception ->
-                Log.d("TAG", "Error getting documents: ", exception)
-            }
-
-        val cardText = view.findViewById<TextView>(R.id.cardTextView)
-        cardText.setText(cards[index].question)
 
         // Previous Card button
         val previousCardBtn = view.findViewById<Button>(R.id.previousCardButton)
@@ -95,7 +64,7 @@ class CardFragment : Fragment() {
             else {
                 index -= 1
             }
-            cardText.setText(cards[index].question)
+            cardText?.text = cards[index].question
 
         }
 
@@ -108,24 +77,24 @@ class CardFragment : Fragment() {
             else {
                 index += 1
             }
-            cardText.setText(cards[index].question)
+            cardText?.text = cards[index].question
         }
 
         // Flip Card Button
         val flipCardBtn = view.findViewById<Button>(R.id.flipCardButton)
         flipCardBtn.setOnClickListener{
-            if (cardText.text == cards[index].question) {
-                cardText.setText(cards[index].answer)
+            if (cardText?.text == cards[index].question) {
+                cardText?.text = cards[index].answer
             }
             else {
-                cardText.setText(cards[index].question)
+                cardText?.text = cards[index].question
             }
         }
 
-        val cardText = view.findViewById<TextView>(R.id.cardTextView)
-        cardText.setText(cards[index].question)
+        /*val cardText = view.findViewById<TextView>(R.id.cardTextView)
+        cardText.setText(cards[index].question)*/
 
-        // Previous Card button
+        /*// Previous Card button
         val previousCardBtn = view.findViewById<Button>(R.id.previousCardButton)
         previousCardBtn.setOnClickListener{
             if (index == 0) {
@@ -134,7 +103,7 @@ class CardFragment : Fragment() {
             else {
                 index -= 1
             }
-            cardText.setText(cards[index].question)
+            cardText?.text = cards[index].question
         }
 
         // Next Card Button
@@ -146,20 +115,20 @@ class CardFragment : Fragment() {
             else {
                 index += 1
             }
-            cardText.setText(cards[index].question)
+            cardText?.text = cards[index].question
         }
 
         // Flip Card Button
         val flipCardBtn = view.findViewById<Button>(R.id.flipCardButton)
         flipCardBtn.setOnClickListener{
-            if (cardText.text == cards[index].question) {
-                cardText.setText(cards[index].answer)
+            if (cardText?.text == cards[index].question) {
+                cardText?.text = cards[index].answer
             }
             else {
-                cardText.setText(cards[index].question)
+                cardText?.text = cards[index].question
             }
-        }
-        */
+        }*/
+
     }
 
     private fun eventChangeListener() {
@@ -168,8 +137,7 @@ class CardFragment : Fragment() {
         var index = 0
         var cardIndex = 0
 
-        database.collection("Decks").document(argsCard.deckId.toString()).collection("cards")
-            .document(argsCard.cardId.toString()).get()
+        database.collection("Decks").document(argsCard.deckId.toString()).collection("cards").get()
             .addOnSuccessListener { result ->
                 for (document in result) {
                     Log.d("TAG", "${document.id} => ${document.data}")
@@ -189,6 +157,7 @@ class CardFragment : Fragment() {
                             index = cardIndex
                         }
                         cardIndex++
+                        view?.findViewById<TextView>(R.id.cardTextView)?.text = cards[index].question
                     }
                 }
             }
@@ -196,7 +165,7 @@ class CardFragment : Fragment() {
                 Log.d("TAG", "Error getting documents: ", exception)
             }
 
-        view?.findViewById<TextView>(R.id.cardTextView)?.text = cards[index].question
+
 
 
     }

--- a/app/src/main/java/com/example/mobil/EditFragment.kt
+++ b/app/src/main/java/com/example/mobil/EditFragment.kt
@@ -26,7 +26,7 @@ private const val ARG_PARAM2 = "param2"
  */
 class EditFragment : Fragment() {
     //testing ********************
-    private val args: DeckFragmentArgs by navArgs()
+    private val args: EditFragmentArgs by navArgs()
     //testing ********************
 
     private var _editBinding: FragmentEditBinding? = null
@@ -111,7 +111,7 @@ class EditFragment : Fragment() {
 
     private fun eventChangeListener(adapter: EditAdapter) {
         database = FirebaseFirestore.getInstance()
-        database.collection("Decks").document(args.docId.toString()).collection("cards").
+        database.collection("Decks").document(args.deckId.toString()).collection("cards").
         addSnapshotListener(object : EventListener<QuerySnapshot> {
             override fun onEvent(
                 value: QuerySnapshot?,

--- a/app/src/main/java/com/example/mobil/MainActivity.kt
+++ b/app/src/main/java/com/example/mobil/MainActivity.kt
@@ -70,6 +70,11 @@ class MainActivity : AppCompatActivity() {
             val directions = MainFragmentDirections.actionMainFragmentToDeckFragment(deckID, deckTitle)
             navController.navigate(directions)
         }
+        // Navigate to EditFragment using ref: "toEdit"
+        if (refString == "toEdit") {
+            val directions = DeckFragmentDirections.actionDeckFragmentToEditFragment(deckID, deckTitle)
+            navController.navigate(directions)
+        }
         // Navigate to CardFragment using ref: "toACard"
         if (refString == "toACard") {
             Log.e("NAVIGATE TO CARD", deckID)

--- a/app/src/main/java/com/example/mobil/adapter/CardsAdapter.kt
+++ b/app/src/main/java/com/example/mobil/adapter/CardsAdapter.kt
@@ -8,15 +8,12 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.mobil.MainActivity
 import com.example.mobil.R
 import com.example.mobil.model.Card
+import com.google.firebase.firestore.Query
 
-class CardsAdapter(val context: MainActivity, private val cards: ArrayList<Card>, val editMenu: () -> Unit) : RecyclerView.Adapter<CardsAdapter.CardsViewHolder>() {
+class CardsAdapter(val context: MainActivity, private val cards: ArrayList<Card>, query : com.google.firebase.firestore.Query) : FirestoreAdapter<CardsAdapter.CardsViewHolder>(query) {
 
     private lateinit var listener : OnCardClickListener
-
-    // *****************EDIT*******************
-    private val selectedCards = arrayListOf<Card>()
-    private var editMode = false
-    // *****************EDIT*******************
+    private lateinit var longListener : OnLongClickListener
 
     interface OnCardClickListener{
         fun onCardClick(position: Int)
@@ -26,67 +23,29 @@ class CardsAdapter(val context: MainActivity, private val cards: ArrayList<Card>
         this.listener = listener
     }
 
+    interface OnLongClickListener{
+        fun onLongClick(position: Int)
+    }
+
+    fun setOnLongClickListener(longListener: OnLongClickListener){
+        this.longListener = longListener
+    }
+
     override fun onCreateViewHolder(viewGroup: ViewGroup, position: Int): CardsViewHolder {
         val myCardsItem = LayoutInflater.from(viewGroup.context).inflate(R.layout.card_item, viewGroup, false)
-        return CardsViewHolder(myCardsItem, listener)
+        return CardsViewHolder(myCardsItem, listener, longListener)
     }
 
     override fun onBindViewHolder(viewHolder: CardsViewHolder, position: Int) {
         val currentCard = cards[position]
         viewHolder.textItem.text = currentCard.question
-
-        // **************************************EDIT**************************************
-        val selectText = viewHolder.itemView.findViewById<TextView>(R.id.selectText)
-
-        if (selectedCards.contains(currentCard)) {
-            selectText.visibility = View.VISIBLE
-        } else {
-            selectText.visibility = View.INVISIBLE
-        }
-
-        viewHolder.itemView.findViewById<CardView>(R.id.card_item_box).setOnClickListener {
-            if (editMode) {
-                selectCard(viewHolder, currentCard)
-            } else {
-                // Testing: Hardcoded the navigation to the deck "asdfasdf" to the card "What was the original color of cola?"
-                Log.e("NAVCONTROLLER: ", "Before navigating to card in CardsAdapter")
-                context.navigateToFragment("toACard", "7WSKo54rMuN24r5lEc9W", "do3Dp9tMrCmT7CnqDE5L", "asdfasdf")
-                Log.e("NAVCONTROLLER: ", "After navigating to card in CardsAdapter")
-            }
-        }
-
-        viewHolder.itemView.findViewById<CardView>(R.id.card_item_box).setOnLongClickListener {
-            if (!editMode) {
-                editMode = true
-                editMenu()
-                selectCard(viewHolder, currentCard)
-            }
-            true
-        }
-        // **************************************EDIT**************************************
     }
-
-    // **************************************EDIT**************************************
-    private fun selectCard(holder: CardsViewHolder, card: Card) {
-        val selectText = holder.itemView.findViewById<TextView>(R.id.selectText)
-        // If the "selectedCards" list contains the card, remove from list and set Invisible
-        if (selectedCards.contains(card)) {
-            selectedCards.remove(card)
-            selectText.visibility = View.INVISIBLE
-        } else {
-            // else, add the card to "selectedCards" and set visible
-            selectedCards.add(card)
-            selectText.visibility = View.VISIBLE
-        }
-    }
-
-    // **************************************EDIT**************************************
 
     override fun getItemCount(): Int {
         return cards.size
     }
 
-    inner class CardsViewHolder (cardView: View, listener: OnCardClickListener) : RecyclerView.ViewHolder(cardView) {
+    inner class CardsViewHolder (cardView: View, listener: OnCardClickListener, longListener: OnLongClickListener) : RecyclerView.ViewHolder(cardView) {
         val textItem = cardView.findViewById<TextView>(R.id.cardTitle)
 
         fun bind(cardItem: Card){
@@ -96,6 +55,10 @@ class CardsAdapter(val context: MainActivity, private val cards: ArrayList<Card>
         init {
             cardView.setOnClickListener{
                 listener.onCardClick(adapterPosition)
+            }
+            cardView.setOnLongClickListener {
+                longListener.onLongClick(adapterPosition)
+                return@setOnLongClickListener true
             }
         }
     }

--- a/app/src/main/res/navigation/my_nav.xml
+++ b/app/src/main/res/navigation/my_nav.xml
@@ -21,7 +21,7 @@
         android:label="{deckTitle}"
         tools:layout="@layout/fragment_deck">
         <argument
-            android:name="docId"
+            android:name="deckId"
             app:argType="string"
             app:nullable="true"
             android:defaultValue="1"/>
@@ -36,6 +36,29 @@
         <action
             android:id="@+id/action_deckFragment_to_mainFragment"
             app:destination="@id/mainFragment" />
+        <action
+            android:id="@+id/action_deckFragment_to_editFragment"
+            app:destination="@id/editFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/editFragment"
+        android:name="com.example.mobil.EditFragment"
+        android:label="{deckTitle}"
+        tools:layout="@layout/fragment_edit">
+        <argument
+            android:name="deckId"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="1"/>
+        <argument
+            android:name="deckTitle"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="1"/>
+        <action
+            android:id="@+id/action_editFragment_to_deckFragment"
+            app:destination="@id/deckFragment" />
     </fragment>
 
     <fragment
@@ -44,15 +67,15 @@
         android:label="{deckTitle}"
         tools:layout="@layout/fragment_card">
         <argument
-            android:name="deckID"
+            android:name="deckId"
             app:argType="string"
             app:nullable="true"
-            android:defaultValue="@null"/>
+            android:defaultValue="1"/>
         <argument
-            android:name="cardID"
+            android:name="cardId"
             app:argType="string"
             app:nullable="true"
-            android:defaultValue="@null"/>
+            android:defaultValue="1"/>
         <argument
             android:name="deckTitle"
             app:argType="string"


### PR DESCRIPTION
* code cleanup in CardFragment, cleanup in certain syntax 
* Reversed changes to edit. we no longer use an edit menu on long click. Long click now navigates to the original edit fragment. This was done for the sake of simplicity and so that we stick to the original planned application. 
* EditAdapter and CardsAdapter are now seperated as they originally were, due to issues with navigation to CardFragment. 
* Added a navigation to editFragment in function in MainActivity (this function will probably need cleanup, because as of now its a bit messy, but it should be simple enough.)
* Added editFragment to navigation layout with an action to navigate back to deckFragment.